### PR TITLE
Add script to fail tests if make is not run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ php:
   - 5.5
   - 5.6
 install: composer install
-script: make test
+script: ./test/build-fail.sh && make test
 sudo: false

--- a/test/build-fail.sh
+++ b/test/build-fail.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+# This will `exit 1` when the git repo hasn't had `make` run properly.
+
+make parsers clean
+
+DIFF=`git diff`
+if [ -n "$DIFF" ]; then
+    echo "DIFF!";
+    echo "'make' has not properly been run before committing.";
+    exit 1;
+fi


### PR DESCRIPTION
This will hopefully prevent an accidental change to one of the parsers without `make` getting run.
