### PR TITLE
Eliminate deprecation errors

### DIFF
--- a/src/Brainy/Compiler/Lexer.php
+++ b/src/Brainy/Compiler/Lexer.php
@@ -143,7 +143,7 @@ class Lexer
         $yy_global_pattern = "/\G(\\{\\})|\G(".$this->ldel."\\*\\s*set strict\\s*\\*".$this->rdel.")|\G(".$this->ldel."\\*([\S\s]*?)\\*".$this->rdel.")|\G(".$this->ldel."\\s*\/block\\s*".$this->rdel.")|\G(".$this->ldel."\\s*\/block\\s*".$this->rdel.")|\G(".$this->ldel."\\s*strip\\s*".$this->rdel.")|\G(".$this->ldel."\\s*\/strip\\s*".$this->rdel.")|\G(".$this->ldel."\\s*literal\\s*".$this->rdel.")|\G(".$this->ldel."\\s*(if|elseif|else if|while)\\s+)|\G(".$this->ldel."\\s*for\\s+)|\G(".$this->ldel."\\s*foreach(?![^\s]))|\G(".$this->ldel."\\s*extends(?![^\s]))|\G(".$this->ldel."\\s*block)|\G(".$this->ldel."\\s*\/)|\G(".$this->ldel."\\s*)|\G(\\s*".$this->rdel.")|\G([\S\s])/iS";
 
         do {
-            if (preg_match($yy_global_pattern,$this->data, $tmpMatches, null, $this->counter)) {
+            if (preg_match($yy_global_pattern,$this->data, $tmpMatches, 0, $this->counter)) {
                 $yysubmatches = $tmpMatches;
                 $yymatches = array();
                 foreach ($tmpMatches as $tmpKey => $tmpMatch) {
@@ -409,7 +409,7 @@ class Lexer
         $yy_global_pattern = "/\G(\")|\G('[^'\\\\]*(?:\\\\.[^'\\\\]*)*')|\G(\\$)|\G(\\s*".$this->rdel.")|\G(\\s+is\\s+in\\s+)|\G(\\s+as\\s+)|\G(\\s+to\\s+)|\G(\\s+step\\s+)|\G(\\s*===\\s*)|\G(\\s*!==\\s*)|\G(\\s*==\\s*|\\s+eq\\s+)|\G(\\s*!=\\s*|\\s*<>\\s*|\\s+(ne|neq)\\s+)|\G(\\s*>=\\s*|\\s+(ge|gte)\\s+)|\G(\\s*<=\\s*|\\s+(le|lte)\\s+)|\G(\\s*>\\s*|\\s+gt\\s+)|\G(\\s*<\\s*|\\s+lt\\s+)|\G(\\s+mod\\s+)|\G(!\\s*|not\\s+)|\G(\\s*&&\\s*|\\s*and\\s+)|\G(\\s*\\|\\|\\s*|\\s*or\\s+)|\G(\\s*xor\\s+)|\G(\\s+is\\s+odd)|\G(\\s+is\\s+even)|\G(\\s+is\\s+div\\s+by\\s+)|\G(\\((int(eger)?|bool(ean)?|float|double|real|string|binary|array|object)\\)\\s*)|\G(\\s*\\(\\s*)|\G(\\s*\\))|\G(\\[\\s*)|\G(\\s*\\])|\G(\\s*->\\s*)|\G(\\s*=>\\s*)|\G(\\s*=\\s*)|\G(\\+\\+|--)|\G(\\s*(\\+|-)\\s*)|\G(\\s*(\\*|\/|%)\\s*)|\G(@)|\G([0-9]*[a-zA-Z_]\\w*)|\G(\\d+)|\G(\\|)|\G(\\.)|\G(\\s*,\\s*)|\G(\\s*;)|\G(\\s*:\\s*)|\G(\\s*&\\s*)|\G(\\s*\\?\\s*)|\G(\\s+)|\G(".$this->ldel."\\s*(if|elseif|else if|while)\\s+)|\G(".$this->ldel."\\s*for\\s+)|\G(".$this->ldel."\\s*foreach(?![^\s]))|\G(".$this->ldel."\\s*\/)|\G(".$this->ldel."\\s*)|\G([\S\s])/iS";
 
         do {
-            if (preg_match($yy_global_pattern,$this->data, $tmpMatches, null, $this->counter)) {
+            if (preg_match($yy_global_pattern,$this->data, $tmpMatches, 0, $this->counter)) {
                 $yysubmatches = $tmpMatches;
                 $yymatches = array();
                 foreach ($tmpMatches as $tmpKey => $tmpMatch) {
@@ -769,7 +769,7 @@ class Lexer
         $yy_global_pattern = "/\G(".$this->ldel."\\s*literal\\s*".$this->rdel.")|\G(".$this->ldel."\\s*\/literal\\s*".$this->rdel.")|\G([\S\s])/iS";
 
         do {
-            if (preg_match($yy_global_pattern,$this->data, $tmpMatches, null, $this->counter)) {
+            if (preg_match($yy_global_pattern,$this->data, $tmpMatches, 0, $this->counter)) {
                 $yysubmatches = $tmpMatches;
                 $yymatches = array();
                 foreach ($tmpMatches as $tmpKey => $tmpMatch) {
@@ -876,7 +876,7 @@ class Lexer
         $yy_global_pattern = "/\G(".$this->ldel."\\s*(if|elseif|else if|while)\\s+)|\G(".$this->ldel."\\s*for\\s+)|\G(".$this->ldel."\\s*foreach(?![^\s]))|\G(".$this->ldel."\\s*\/)|\G(".$this->ldel."\\s*)|\G(\")|\G(\\$[0-9]*[a-zA-Z_]\\w*)|\G(\\$)|\G(([^\"\\\\]*?)((?:\\\\.[^\"\\\\]*?)*?)(?=(".$this->ldel."|\\$|\")))|\G([\S\s])/iS";
 
         do {
-            if (preg_match($yy_global_pattern,$this->data, $tmpMatches, null, $this->counter)) {
+            if (preg_match($yy_global_pattern,$this->data, $tmpMatches, 0, $this->counter)) {
                 $yysubmatches = $tmpMatches;
                 $yymatches = array();
                 foreach ($tmpMatches as $tmpKey => $tmpMatch) {

--- a/src/Brainy/plugins/function.html_select_date.php
+++ b/src/Brainy/plugins/function.html_select_date.php
@@ -322,8 +322,8 @@ function smarty_function_html_select_date($params, $template)
 
         for ($i = 1; $i <= 12; $i++) {
             $_val = sprintf('%02d', $i);
-            $_text = isset($options['month_names']) ? smarty_function_escape_special_chars($options['month_names'][$i]) : ($options['month_format'] == "%m" ? $_val : strftime($options['month_format'], $_month_timestamps[$i]));
-            $_value = $options['month_value_format'] == "%m" ? $_val : strftime($options['month_value_format'], $_month_timestamps[$i]);
+            $_text = isset($options['month_names']) ? smarty_function_escape_special_chars($options['month_names'][$i]) : ($options['month_format'] == "%m" ? $_val : __brainy_format_month($options['month_format'], $_month_timestamps[$i]));
+            $_value = $options['month_value_format'] == "%m" ? $_val : __brainy_format_month($options['month_value_format'], $_month_timestamps[$i]);
             $_html_months .= '<option value="' . $_value . '"'
                 . ($_val == $timeData['_month'] ? ' selected="selected"' : '')
                 . '>' . $_text . '</option>' . $options['option_separator'];
@@ -408,4 +408,23 @@ function smarty_function_html_select_date($params, $template)
     }
 
     return $_html;
+}
+
+/**
+ * This function behaves like strftime(). strftime() is deprecated, though,
+ * so this translates the format to a `DateTime::format`-compatible format for
+ * use with date().
+ */
+function __brainy_format_month($strftime_format, $value) {
+    switch ($strftime_format) {
+        case '%b':
+        case '%h':
+            return date('M', $value);
+        case '%B':
+            return date('F', $value);
+        case '%m':
+            return date('m', $value);
+        default:
+            throw new \Box\Brainy\Exceptions\SmartyException("Cannot use month format '$strftime_format'");
+    }
 }


### PR DESCRIPTION
The `flags` parameter of `preg_match` no longer accepts `null` and instead defaults to `0`. Changing this eliminates the deprecation warnings raised by the use of `preg_match` in the lexer, which eliminates many hundreds of noisy messages when running the tests (and probably improves runtime performance in newer versions of PHP).

Edit: I've also updated this PR to eliminate deprecation warnings related to `strftime()` usage in `html_select_date`. `strftime` is deprecated in favor of `date`. The current use for `strftime` is to translate a configurable date format for both the value and the label of a select box (that is, the content and `value=""` attribute of the generated `<option>` tags). My change preserves all possible `strftime` month formatting values, though it does create a minor backwards-incompatible change where someone who may have been abusing the `month_format` or `month_value_format` arguments to render non-month dates (e.g., rendering the current year for the value) would start seeing exceptions. This is pretty unlikely, since the rendered output doesn't make a whole lot of sense.

When bumping versions after this PR, there should be a minor version bump, not just a patch version.